### PR TITLE
Change git clone link to HTTPS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Installation
 Clone the repository:
 
 
-	$ git clone git@github.com:oussamak/lemp-stack.git
+	$ git clone https://github.com/oussaka/lemp-stack.git
 	$ cd lemp-stack
 
 Then, you should be able to use:


### PR DESCRIPTION
There was a permission error when cloning the git repo through SSH, so I switched it to HTTPS.
